### PR TITLE
[Merge]Hotfix frontend quiz taking to feature quiz taking

### DIFF
--- a/project/frontend/src/components/TakeQuiz/AnswnerOption.vue
+++ b/project/frontend/src/components/TakeQuiz/AnswnerOption.vue
@@ -1,6 +1,8 @@
 <template>
     <div class="option-container">
-        <button v-for="(option, i) in options" :key="i" @click="answerSelected(option)" class="option" :style="{ 'background-color': this.color[i]}">{{ option }}</button>
+        <button v-for="(option, i) in options" :key="i" @click="answerSelected(option)" class="option" :class="{ 'selected': selectedOption === option }" :style="{ 'background-color': this.color[i]}">
+            {{ option }}
+        </button>
     </div>
 </template>
 
@@ -9,7 +11,8 @@ export default {
     name: "AnswnerOption",
     data() {
         return {
-            color: ['#ff6666', '#6666ff', '#ffff66', '#66ff66']
+            color: ['#ff6666', '#6666ff', '#ffff66', '#66ff66'],
+            selectedOption: null
         }
     },
 
@@ -22,14 +25,13 @@ export default {
     },
 
     methods: {
-        
         answerSelected(option) {
-            this.$emit("answerSelected", option)
+            this.selectedOption = option;
+            this.$emit("answerSelected", option);
         }
     }
 }
 </script>
-
 
 <style scoped>
 .option-container {
@@ -40,15 +42,21 @@ export default {
     padding: 1vh 1vw 1vh 1vw;
 }
 
-.option{
+.option {
     width: 48vw;
     height: 15vh;
     font-size: 3vw;
-    font-style: normal
+    font-style: normal;
+    transition: transform 0.2s, border 0.2s;
 }
 
-.option:hover{
+.option:hover {
     transform: scale(1.01);
     background-color: #333;
+}
+
+.option.selected {
+    border: 5px solid #000;
+    transform: scale(1.02);
 }
 </style>

--- a/project/frontend/src/components/TakeQuiz/AnswnerOption.vue
+++ b/project/frontend/src/components/TakeQuiz/AnswnerOption.vue
@@ -1,6 +1,13 @@
 <template>
     <div class="option-container">
-        <button v-for="(option, i) in options" :key="i" @click="answerSelected(option)" class="option" :class="{ 'selected': selectedOption === option }" :style="{ 'background-color': this.color[i]}">
+        <button
+            v-for="(option, i) in options"
+            :key="i"
+            @click="answerSelected(option)"
+            class="option"
+            :class="{ 'selected': selectedOption === option }"
+            :style="{ 'background-color': this.color[i] }"
+        >
             {{ option }}
         </button>
     </div>
@@ -9,24 +16,24 @@
 <script>
 export default {
     name: "AnswnerOption",
-    data() {
-        return {
-            color: ['#ff6666', '#6666ff', '#ffff66', '#66ff66'],
-            selectedOption: null
-        }
-    },
-
     props: {
         options: {
             type: Array,
             required: true,
             default: []
+        },
+        selectedOption: {
+            type: String,
+            default: null
         }
     },
-
+    data() {
+        return {
+            color: ['#ff6666', '#6666ff', '#ffff66', '#66ff66']
+        }
+    },
     methods: {
         answerSelected(option) {
-            this.selectedOption = option;
             this.$emit("answerSelected", option);
         }
     }

--- a/project/frontend/src/components/TakeQuiz/QuestionDashboard.vue
+++ b/project/frontend/src/components/TakeQuiz/QuestionDashboard.vue
@@ -1,0 +1,76 @@
+<template>
+    <div class="dashboard">
+        <button @click="navigateToPreviousQuestion" :disabled="currentQuestionIndex === 0">Previous</button>
+        <button v-for="(question, index) in questions" :key="index" @click="navigateToQuestion(index)" :class="{'current': index === currentQuestionIndex}">
+            {{ index + 1 }}
+        </button>
+        <button @click="navigateToNextQuestion" :disabled="currentQuestionIndex === questions.length - 1">Next</button>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "QuestionDashboard",
+    props: {
+        questions: {
+            type: Array,
+            required: true
+        },
+        currentQuestionIndex: {
+            type: Number,
+            required: true
+        }
+    },
+    methods: {
+        navigateToQuestion(index) {
+            this.$emit("navigateToQuestion", index);
+        },
+        navigateToPreviousQuestion() {
+            if (this.currentQuestionIndex > 0) {
+                this.$emit("navigateToQuestion", this.currentQuestionIndex - 1);
+            }
+        },
+        navigateToNextQuestion() {
+            if (this.currentQuestionIndex < this.questions.length - 1) {
+                this.$emit("navigateToQuestion", this.currentQuestionIndex + 1);
+            }
+        }
+    }
+}
+</script>
+
+<style scoped>
+.dashboard {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 10px;
+    background-color: #f0f0f0;
+    border-bottom: 1px solid #ccc;
+}
+
+.dashboard button {
+    margin: 5px;
+    padding: 10px;
+    font-size: 1.2em;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.dashboard button.current {
+    background-color: #007bff;
+    color: white;
+}
+
+.dashboard button:hover {
+    background-color: #0056b3;
+    color: white;
+}
+
+.dashboard button:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+}
+</style>

--- a/project/frontend/src/views/QuizView/TakeQuiz.vue
+++ b/project/frontend/src/views/QuizView/TakeQuiz.vue
@@ -7,7 +7,7 @@
         <div class="submit-container">
             <button class="submit-button" @click="checkAndSubmit">Submit</button>
         </div>
-        <AnswnerOption :options="currentOptions" @answerSelected="handleAnswer($event)" />
+        <AnswnerOption :options="currentOptions" :selectedOption="currentSelectedOption" @answerSelected="handleAnswer($event)" />
     </div>
     <SubmitPopup v-if="showSubmitPopup" @submitOption="handleSubmit($event)" />
 </template>
@@ -164,6 +164,9 @@ export default {
                 console.error(e);
                 return [];
             }
+        },
+        currentSelectedOption() {
+            return this.answerSheet[this.currentQuestionIndex].Choosed_ans;
         }
     },
 

--- a/project/frontend/src/views/QuizView/TakeQuiz.vue
+++ b/project/frontend/src/views/QuizView/TakeQuiz.vue
@@ -1,13 +1,12 @@
 <template>
-
     <div class="container" data-v-inspector="src/views/QuizView/TakeQuiz.vue:2:5">
         <QuizHeader :currentQuestionIndex="currentQuestionIndex" :questionCount="questionCount" @exit="backToLastPage()"
             data-v-inspector="src/views/QuizView/TakeQuiz.vue:3:9" />
+        <QuestionDashboard :questions="testSheet" :currentQuestionIndex="currentQuestionIndex" @navigateToQuestion="navigateToQuestion" />
         <QuizBody :body="currentBodyDescription" />
         <AnswnerOption :options="currentOptions" @answerSelected="handleAnswer($event)" />
     </div>
     <SubmitPopup v-if="showSubmitPopup" @submitOption="handleSubmit($event)" />
-
 </template>
 
 <script>
@@ -17,6 +16,7 @@ import AnswnerOption from "@/components/TakeQuiz/AnswnerOption.vue";
 import { getTestSheetByQuizID_fake, submitTestSheet_fake } from "@/service/QuizApi/TestSheetAPI";
 import { useQuizStore } from "@/stores/Userlibrary/QuizQuestionStore";
 import SubmitPopup from "@/components/TakeQuiz/SubmitPopup.vue";
+import QuestionDashboard from "@/components/TakeQuiz/QuestionDashboard.vue";
 
 export default {
     name: "TakeQuiz",
@@ -25,7 +25,8 @@ export default {
         QuizHeader,
         QuizBody,
         AnswnerOption,
-        SubmitPopup
+        SubmitPopup,
+        QuestionDashboard
     },
 
     data() {
@@ -69,9 +70,7 @@ export default {
     },
 
     methods: {
-
         handleAnswer(option) {
-
             // set the chosen answer
             this.answerSheet[this.currentQuestionIndex].answer = option
             // end of the quiz
@@ -81,28 +80,21 @@ export default {
             }
 
             this.currentQuestionIndex++;
-
-
         },
 
         async handleSubmit(doSubmit) {
-
             // User wants to submit
             if (doSubmit) {
-
                 try {
                     // TODO replace fake service
                     const response = await submitTestSheet_fake({
                         User_id: this.userID,
                         Quiz_id: this.quizID,
                         Answer_sheet: this.answerSheet
-                    }
-                    );
+                    });
 
                     const recordId = response.data.recordID;
                     if (response.status == 200) {
-
-                        
                         console.log("Submit Successfully. recordID=", recordId);
 
                         // Uncomment the following code when integrating.
@@ -113,13 +105,14 @@ export default {
                         //     }
                         // })
                     }
-                }catch(e){
+                } catch (e) {
                     console.error(e);
                 }
             }
 
             this.showSubmitPopup = false;
         },
+
         restartQuiz() {
             this.currentQuestionIndex = 0;
             this.score = 0;
@@ -132,6 +125,10 @@ export default {
             } catch (e) {
                 this.$router.push('/');
             }
+        },
+
+        navigateToQuestion(index) {
+            this.currentQuestionIndex = index;
         }
     },
 
@@ -139,8 +136,7 @@ export default {
         currentBodyDescription() {
             try {
                 return this.testSheet[this.currentQuestionIndex].body;
-            }
-            catch (e) {
+            } catch (e) {
                 return "Undefined";
             }
         },
@@ -158,8 +154,7 @@ export default {
                 console.error(e);
                 return [];
             }
-        },
-
+        }
     },
 
     watch: {


### PR DESCRIPTION
# About PR
## Features
- Taking quiz and submit answer sheet.

## File Structures
src
├── components
│   └── TakeQuiz
 |        |-----QuestionDashboard.vue
│       ├── AnswerOption.vue
│       ├── QuizBody.vue
│       ├── QuizHeader.vue
│       └── SubmitPopup.vue
├── router
│   └── index.js
├── service
│   └── QuizApi
│       └── TestSheetAPI.js
├── views
│   └── QuizView
│       └── TakeQuiz.vue


This pull request includes significant updates to the quiz functionality in the frontend. The changes enhance the user interface for answering questions, add navigation between questions, and introduce a new question dashboard component. The most important changes include updating the `AnswnerOption` component to highlight selected options, adding a `QuestionDashboard` component for navigating between questions, and modifying the `TakeQuiz` view to integrate these new features.

Enhancements to `AnswnerOption` component:

* Updated the `AnswnerOption` component to highlight the selected option by adding a `selectedOption` data property and modifying the `answerSelected` method to update this property. Added CSS for the `.selected` class to visually indicate the selected option. [[1]](diffhunk://#diff-6516532d1840dfb206b911a8fa835e70998d9fe646f2fca2e39873f5b7441baaL3-R5) [[2]](diffhunk://#diff-6516532d1840dfb206b911a8fa835e70998d9fe646f2fca2e39873f5b7441baaL12-R15) [[3]](diffhunk://#diff-6516532d1840dfb206b911a8fa835e70998d9fe646f2fca2e39873f5b7441baaL25-L33) [[4]](diffhunk://#diff-6516532d1840dfb206b911a8fa835e70998d9fe646f2fca2e39873f5b7441baaL47-R61)

Introduction of `QuestionDashboard` component:

* Added a new `QuestionDashboard` component to allow users to navigate between questions. This component includes buttons for each question and navigation buttons for moving to the previous or next question.

Integration of `QuestionDashboard` in `TakeQuiz` view:

* Integrated the `QuestionDashboard` component into the `TakeQuiz` view, allowing users to navigate between questions. Updated the `TakeQuiz` view to include methods for handling question navigation and a submit button with validation for incomplete questions. [[1]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeL2-L10) [[2]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeR22) [[3]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeL28-R32) [[4]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeL40-R45) [[5]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeL53-R64) [[6]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeL72-L105) [[7]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeR113) [[8]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeR126-R149) [[9]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeL161-R167) [[10]](diffhunk://#diff-8ecc2ee19f5221bf82d28d15797dd5b80bd525f40ff1f17aba91ffffff295edeR187-R205)


## Dependency
- TakeQuiz contains AnswerOption, QuizBody, QuizHeader and SubmitPopup.
- All events in components will be emitted back to TakeQuiz(The controller).
- TakeQuiz uses "getTestSheetByQuizID" and "submitAnswerSheet" from TestSheetAPI.

## How to test
1.  `git switch hotfix_frontend_quiz_taking`
2. `cd project/frontend`
3. `npm i`
4. `npm run dev`
5. open other terminal
6. `cd project/backend`
7. `npm i`
8. `npm run dev`
9. open the link `http://127.0.0.1:5173/UserLibrary`
10. select any quiz to the edit view
11. click "Try Quiz" then enter the quiz taking view
![image](https://github.com/user-attachments/assets/d44eadf4-8092-457b-bb95-790eaea39fb7)

## Reminder
- 增加了dashboard 
- 選的選項加粗
- 要全寫完否則不行交
